### PR TITLE
Add support for periods

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 module.exports = function (str) {
-	return encodeURIComponent(str).replace(/[!'()*]/g, function (c) {
-		return '%' + c.charCodeAt(0).toString(16);
+	return encodeURIComponent(str).replace(/[.!'()*]/g, function (c) {
+		return '%' + c.charCodeAt(0).toString(16).toUpperCase();
 	});
 };

--- a/readme.md
+++ b/readme.md
@@ -15,11 +15,14 @@ $ npm install --save strict-uri-encode
 ```js
 var strictUriEncode = require('strict-uri-encode');
 
-strictUriEncode('unicorn*foobar')
-//=> 'unicorn%2afoobar'
-
 strictUriEncode('unicorn!foobar')
 //=> 'unicorn%21foobar'
+
+strictUriEncode('unicorn*foobar')
+//=> 'unicorn%2Afoobar'
+
+strictUriEncode('unicorn.foobar')
+//=> 'unicorn%2Efoobar'
 ```
 
 

--- a/test.js
+++ b/test.js
@@ -5,7 +5,9 @@ var strictUriEncode = require('./');
 test(function (t) {
 	t.assert(strictUriEncode('unicorn!foobar') === 'unicorn%21foobar');
 	t.assert(strictUriEncode('unicorn\'foobar') === 'unicorn%27foobar');
-	t.assert(strictUriEncode('unicorn*foobar') === 'unicorn%2afoobar');
+	t.assert(strictUriEncode('unicorn*foobar') === 'unicorn%2Afoobar');
 	t.assert(strictUriEncode('unicorn*foobar') !== encodeURIComponent('unicorn*foobar'));
+	t.assert(strictUriEncode('unicorn.foobar') === 'unicorn%2Efoobar');
+	t.assert(strictUriEncode('unicorn.foobar') !== encodeURIComponent('unicorn.foobar'));
 	t.end();
 });


### PR DESCRIPTION
I'm not sure if this PR is wanted but I needed it to work with [firebase](https://www.firebase.com), specificaly it's [key names](https://www.firebase.com/docs/web/guide/understanding-data.html#section-creating-references).

>  A child node's key cannot be longer than 768 bytes, nor deeper than 32 levels. It can include any unicode characters except for . $ # [ ] / and ASCII control characters 0-31 and 127.

This PR encodes periods `.` as `%2E` as well as running the result through `toUpperCase`.
