### PR TITLE
Specify `main` entry for the project

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "scripts": {
     "test": "xo && ava"
   },
+  "main": "index.js",
   "files": [
     "index.js"
   ],


### PR DESCRIPTION
The `main` entry in the `package.json` is used by `webjar-locator` to build the RequireJS configuration for this project.
