### PR TITLE
Convert Arrow Function to ES5

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,2 +1,4 @@
 'use strict';
-module.exports = str => encodeURIComponent(str).replace(/[!'()*]/g, x => `%${x.charCodeAt(0).toString(16).toUpperCase()}`);
+module.exports = function (str) {
+	return encodeURIComponent(str).replace(/[!'()*]/g, x => `%${x.charCodeAt(0).toString(16).toUpperCase()}`);
+};

--- a/index.js
+++ b/index.js
@@ -1,4 +1,9 @@
 'use strict';
 module.exports = function (str) {
-	return encodeURIComponent(str).replace(/[!'()*]/g, x => `%${x.charCodeAt(0).toString(16).toUpperCase()}`);
+	return encodeURIComponent(str).replace(/[!'()*]/g, function (x) {
+		return `%${x
+			.charCodeAt(0)
+			.toString(16)
+			.toUpperCase()}`;
+	});
 };

--- a/package.json
+++ b/package.json
@@ -27,5 +27,10 @@
 	"devDependencies": {
 		"ava": "*",
 		"xo": "*"
+	},
+	"xo": {
+		"rules": {
+			"prefer-arrow-callback": 0
+		}
 	}
 }

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import m from '.';
 
-test(t => {
+test('strict-uri-encode', t => {
 	t.is(m('unicorn!foobar'), 'unicorn%21foobar');
 	t.is(m('unicorn\'foobar'), 'unicorn%27foobar');
 	t.is(m('unicorn*foobar'), 'unicorn%2Afoobar');


### PR DESCRIPTION
I know this issue has been covered. Hoping that you will reconsider writing this fine lib as a good 'ol function.

I understand not wanting to target for the browser, but for this library at least, it's one very small fix for that would save a lot of folks an extra dependency. JS devs everywhere will thank you!

Thanks for considering.